### PR TITLE
Use new name of testinfra

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,5 +6,5 @@ flake8-docstrings
 flake8-isort
 molecule
 molecule-docker
+pytest-testinfra
 python-jenkins
-testinfra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -141,7 +141,9 @@ pynacl==1.4.0
 pyparsing==2.4.7
     # via packaging
 pytest==6.0.1
-    # via testinfra
+    # via pytest-testinfra
+pytest-testinfra==6.4.0
+    # via -r requirements-dev.in
 python-dateutil==2.8.1
     # via arrow
 python-jenkins==1.7.0
@@ -195,8 +197,6 @@ tenacity==8.0.1
     # via ansible-lint
 testfixtures==6.18.1
     # via flake8-isort
-testinfra==5.2.2
-    # via -r requirements-dev.in
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.1


### PR DESCRIPTION
It was renamed from testinfra to pytest-testinfra in version 6.0.0.