### PR TITLE
Fix Windows versions in metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,8 +22,7 @@ galaxy_info:
         - all
     - name: Windows
       versions:
-        - 8.1
-        - 10
+        - all
 
 dependencies:
   - ableton.pkg_mgr_path


### PR DESCRIPTION
This fixes a warning from Ansible Galaxy about unknown Windows versions when importing the role.