### PR TITLE
Add yamllint check to Jenkinsfile

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,4 +1,8 @@
 ---
+ignore: |
+  .ansible
+  .venv
+
 extends: default
 
 rules:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ devToolsProject.run(
           data.venv.run('molecule --debug test')
         }
       },
+      yamllint: { data.venv.run('yamllint --strict .') },
     )
   },
   deployWhen: { devToolsProject.shouldDeploy(defaultBranch: 'main') },


### PR DESCRIPTION
Although ansible-lint uses yamllint as a dependency, it is nice to have a separate yamllint check in the Jenkinsfile.