### PR TITLE
Remove ansible pip package from requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,3 @@
-ansible
 ansible-lint
 black
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,16 +4,12 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-ansible==6.1.0
-    # via -r requirements-dev.in
 ansible-compat==2.1.0
     # via
     #   ansible-lint
     #   molecule
 ansible-core==2.13.1
-    # via
-    #   ansible
-    #   ansible-lint
+    # via ansible-lint
 ansible-lint==6.3.0
     # via -r requirements-dev.in
 arrow==0.15.8
@@ -73,8 +69,6 @@ flake8-isort==4.2.0
     # via -r requirements-dev.in
 idna==2.10
     # via requests
-importlib-resources==5.7.1
-    # via jsonschema
 iniconfig==1.0.0
     # via pytest
 isort==5.9.3
@@ -195,8 +189,6 @@ toml==0.10.1
     # via pytest
 tomli==1.2.1
     # via black
-typing-extensions==3.10.0.2
-    # via black
 urllib3==1.26.5
     # via requests
 wcmatch==8.2
@@ -205,8 +197,6 @@ websocket-client==0.57.0
     # via docker
 yamllint==1.26.3
     # via ansible-lint
-zipp==3.8.0
-    # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Now that we have specified all collections this role requires in the requirements.yml file, we can remove this legacy package.