### PR TITLE
Define KeepAlive to true, remove NetworkState

### DIFF
--- a/templates/org.jenkins-ci.plugins.swarm.plist.j2
+++ b/templates/org.jenkins-ci.plugins.swarm.plist.j2
@@ -8,10 +8,7 @@
     <string>{{ ansible_pkg_mgr_path }}</string>
   </dict>
   <key>KeepAlive</key>
-  <dict>
-    <key>NetworkState</key>
-    <true/>
-  </dict>
+  <true/>
   <key>Label</key>
   <string>{{ jenkins_swarm_client_ident }}</string>
   <key>MachServices</key>


### PR DESCRIPTION
According to the manpage for `launchd.plist` on Catalina (and newer)
macOS versions:

> This key is no longer implemented as it never acted how most users
> expected.
