### PR TITLE
Remove community.docker role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,8 +2,6 @@
 collections:
   - name: ansible.windows
     version: 1.12.0
-  - name: community.docker
-    version: 3.2.2
   - name: community.windows
     version: 1.11.1
 


### PR DESCRIPTION
This role was previously needed for the molecule-docker package, but in version 2.1.0 this dependency was fixed, so we shouldn't need to add this collection to our requirements.yml file anymore.