### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,4 +16,4 @@
     jenkins_swarm_home: "/jenkins"
     swarm_client_create_user: true
   roles:
-    - role: ansible-role-jenkins-swarm-client
+    - role: ableton.jenkins_swarm_client


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.