### PR TITLE
Update ableton-utils to 0.26

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.24', changelog: false)
+library(identifier: 'ableton-utils@0.26', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 


### PR DESCRIPTION
This is needed to fix importing roles into Ansible Galaxy.